### PR TITLE
feat(xlsx-viewer): expose getCellStyle for custom per-cell styling

### DIFF
--- a/apps/v4/components/ui/xlsx-viewer.tsx
+++ b/apps/v4/components/ui/xlsx-viewer.tsx
@@ -13,6 +13,7 @@ import {
   type XlsxSheetData,
   type XlsxTableHeaderMenuRenderProps,
   type XlsxViewerController,
+  type XlsxViewerProps,
 } from "@extend-ai/react-xlsx"
 import {
   ArrowLeft01Icon,
@@ -1301,6 +1302,7 @@ const WorkbookSheetTabsInner = React.memo(function WorkbookSheetTabsInner({
 
 export function XlsxWorkbookSurface({
   className,
+  getCellStyle,
   isDark,
   onDownload,
   onIsDarkChange,
@@ -1314,6 +1316,7 @@ export function XlsxWorkbookSurface({
   workbookIdentity,
 }: {
   className?: string
+  getCellStyle?: XlsxViewerProps["getCellStyle"]
   isDark: boolean
   onDownload?: () => void
   onIsDarkChange: (checked: boolean) => void
@@ -1370,6 +1373,7 @@ export function XlsxWorkbookSurface({
             experimentalCanvas
             allowResizeInReadOnly
             className="h-full min-h-0 min-w-0"
+            getCellStyle={getCellStyle}
             height="100%"
             isDark={isDark}
             readOnly
@@ -1406,6 +1410,7 @@ export function XlsxWorkbookSurface({
 export function XlsxViewerPreview({
   className,
   fileName,
+  getCellStyle,
   isDark,
   onIsDarkChange,
   showDownload = true,
@@ -1416,6 +1421,7 @@ export function XlsxViewerPreview({
 }: {
   className?: string
   fileName?: string
+  getCellStyle?: XlsxViewerProps["getCellStyle"]
   isDark: boolean
   onIsDarkChange: (isDark: boolean) => void
   showDownload?: boolean
@@ -1429,6 +1435,7 @@ export function XlsxViewerPreview({
       className={className}
       effectiveIsDark={isDark}
       fileName={fileName}
+      getCellStyle={getCellStyle}
       setNightRenderEnabled={onIsDarkChange}
       shouldRenderNightMode
       showDownload={showDownload}
@@ -1444,6 +1451,7 @@ function XlsxViewerContent({
   className,
   effectiveIsDark,
   fileName,
+  getCellStyle,
   setNightRenderEnabled,
   shouldRenderNightMode,
   showDownload,
@@ -1455,6 +1463,7 @@ function XlsxViewerContent({
   className?: string
   effectiveIsDark: boolean
   fileName?: string
+  getCellStyle?: XlsxViewerProps["getCellStyle"]
   setNightRenderEnabled: (checked: boolean) => void
   shouldRenderNightMode: boolean
   showDownload: boolean
@@ -1667,6 +1676,7 @@ function XlsxViewerContent({
       <XlsxWorkbookLoadedViewer
         className={className}
         fileName={activeFileName}
+        getCellStyle={getCellStyle}
         isDark={effectiveIsDark}
         onDownload={() => downloadWorkbookBuffer(activeBuffer, activeFileName)}
         onIsDarkChange={setNightRenderEnabled}
@@ -1689,6 +1699,7 @@ function XlsxViewerContent({
 function XlsxWorkbookLoadedViewer({
   className,
   fileName,
+  getCellStyle,
   isDark,
   onDownload,
   onIsDarkChange,
@@ -1704,6 +1715,7 @@ function XlsxWorkbookLoadedViewer({
 }: {
   className?: string
   fileName: string
+  getCellStyle?: XlsxViewerProps["getCellStyle"]
   isDark: boolean
   onDownload: () => void
   onIsDarkChange: (checked: boolean) => void
@@ -1737,6 +1749,7 @@ function XlsxWorkbookLoadedViewer({
     <XlsxViewerProvider controller={controller} isDark={isDark}>
       <XlsxWorkbookSurface
         className={className}
+        getCellStyle={getCellStyle}
         isDark={isDark}
         onDownload={onDownload}
         onIsDarkChange={onIsDarkChange}

--- a/apps/v4/content/docs/components/xlsx-viewer.mdx
+++ b/apps/v4/content/docs/components/xlsx-viewer.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @extend/xlsx-viewer
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install @extend-ai/react-xlsx@^0.10.0 @hugeicons/core-free-icons@^4.2.0 @hugeicons/react@^1.1.6
+npm install @extend-ai/react-xlsx@^0.11.0 @hugeicons/core-free-icons@^4.2.0 @hugeicons/react@^1.1.6
 ```
 
 <Step>Copy and paste the following code into your project.</Step>
@@ -60,10 +60,13 @@ npm install @extend-ai/react-xlsx@^0.10.0 @hugeicons/core-free-icons@^4.2.0 @hug
 
 The XlsxViewerPreview component renders an Excel workbook with upload, theme, zoom, sheet navigation, and grid controls around the `@extend-ai/react-xlsx` viewer.
 
-| Prop             | Type                        | Default | Required |
-| ---------------- | --------------------------- | ------- | -------- |
-| `className`      | `string`                    | `-`     | No       |
-| `fileName`       | `string`                    | `-`     | No       |
-| `isDark`         | `boolean`                   | `-`     | Yes      |
-| `onIsDarkChange` | `(isDark: boolean) => void` | `-`     | Yes      |
-| `src`            | `string`                    | `-`     | No       |
+| Prop             | Type                                                                          | Default | Required |
+| ---------------- | ----------------------------------------------------------------------------- | ------- | -------- |
+| `className`      | `string`                                                                      | `-`     | No       |
+| `fileName`       | `string`                                                                      | `-`     | No       |
+| `getCellStyle`   | `(context: XlsxCellStyleContext) => React.CSSProperties \| null \| undefined` | `-`     | No       |
+| `isDark`         | `boolean`                                                                     | `-`     | Yes      |
+| `onIsDarkChange` | `(isDark: boolean) => void`                                                   | `-`     | Yes      |
+| `src`            | `string`                                                                      | `-`     | No       |
+
+Use `getCellStyle` to apply custom per-cell styling (highlights, outlines, status tints) on top of the workbook's own formatting. It is forwarded to the underlying `@extend-ai/react-xlsx` viewer; see its documentation for the `XlsxCellStyleContext` fields and renderer notes.

--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -37,7 +37,7 @@
     "@embedpdf/plugin-viewport": "^2.14.4",
     "@embedpdf/plugin-zoom": "^2.14.4",
     "@extend-ai/react-docx": "0.7.1",
-    "@extend-ai/react-xlsx": "0.10.2",
+    "@extend-ai/react-xlsx": "0.11.0",
     "@glideapps/glide-data-grid": "6.0.4-alpha24",
     "@hugeicons/core-free-icons": "^4.2.0",
     "@hugeicons/react": "^1.1.6",

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -733,7 +733,7 @@
       "title": "Excel Viewer",
       "description": "An XLSX viewer with workbook loading, thumbnails, sheet tabs, upload, zoom, and theme controls.",
       "dependencies": [
-        "@extend-ai/react-xlsx@^0.10.0",
+        "@extend-ai/react-xlsx@^0.11.0",
         "@hugeicons/core-free-icons@^4.2.0",
         "@hugeicons/react@^1.1.6"
       ],
@@ -763,7 +763,7 @@
       "title": "Excel Editor",
       "description": "An experimental XLSX editor with formula input, undo and redo, sheet controls, export, and live workbook mutation.",
       "dependencies": [
-        "@extend-ai/react-xlsx@^0.10.0",
+        "@extend-ai/react-xlsx@^0.11.0",
         "@hugeicons/core-free-icons@^4.2.0",
         "@hugeicons/react@^1.1.6"
       ],


### PR DESCRIPTION
## Summary

Forwards the new `getCellStyle` prop from `@extend-ai/react-xlsx` through the `@extend/xlsx-viewer` registry component, so consumers can apply custom per-cell styling (highlights, outlines, status tints) on top of the workbook's own Excel formatting — without forking the component.

- Threads `getCellStyle` through `XlsxViewerPreview → XlsxViewerContent → XlsxWorkbookLoadedViewer → XlsxWorkbookSurface → XlsxViewer`, typed via `XlsxViewerProps["getCellStyle"]` so the signature stays in sync with the underlying package.
- Bumps the `@extend-ai/react-xlsx` dependency (`package.json` + `registry.json`) to the release that adds the prop.
- Documents `getCellStyle` in the component's API reference.

## Dependency / status

> **Draft** — blocked on `getCellStyle` shipping in a published `@extend-ai/react-xlsx` release (upstream: extend-hq/react-xlsx#8). The version pin here is provisional and should be matched to whatever release includes that change. Ready to mark for review once the package is published.

## Test plan

- [x] `pnpm typecheck` (verified locally against a `getCellStyle`-enabled build of the package)
- [x] `pnpm registry:validate`
- [x] `prettier --check` on changed files
- [ ] `pnpm build` once the dependency release is available